### PR TITLE
[refactor] separate socket_client specification from socket process

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ defmodule MyChannel do
 
   def handle_in("new_msg", payload, state) do
     {:noreply, state}
-  end  
+  end
 
   def handle_reply({:ok, "new_msg", resp, _ref}, state) do
     {:noreply, state}

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,3 +22,4 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+

--- a/lib/phoenix_channel_client.ex
+++ b/lib/phoenix_channel_client.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.Channel.Client do
 
   defcallback handle_reply(reply :: Tuple.t, state :: map) ::
               {:noreply, state :: map}
-              
+
   defcallback handle_close(reply :: Tuple.t, state :: map) ::
               {:noreply, state :: map} |
               {:stop, reason :: term, state :: map}

--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -45,7 +45,8 @@
   end
 
   def websocket_terminate(reason, _conn_state, state) do
-    send state.sender, {:closed, reason}
-    :ok
-  end
+     send state.sender, {:closed, reason}
+     :timer.sleep(1000)
+     :ok
+   end
 end

--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
+  defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
   @behaviour Phoenix.Channel.Client.Adapter
 
   require Logger

--- a/lib/phoenix_channel_client/socket.ex
+++ b/lib/phoenix_channel_client/socket.ex
@@ -145,4 +145,9 @@ defmodule Phoenix.Channel.Client.Socket do
     state.sender.handle_close(reason, %{state | state: :disconnected})
   end
 
+  def terminate(reason, state) do
+   state.sender.handle_close(reason, %{state | state: :disconnected})
+   :ok
+  end
+
 end

--- a/lib/phoenix_channel_client/socket.ex
+++ b/lib/phoenix_channel_client/socket.ex
@@ -67,6 +67,7 @@ defmodule Phoenix.Channel.Client.Socket do
       sender: sender,
       opts: opts,
       socket: nil,
+      socket_client: nil,
       channels: [],
       reconnect: reconnect,
       heartbeat_interval: heartbeat_interval,

--- a/lib/phoenix_channel_client/socket.ex
+++ b/lib/phoenix_channel_client/socket.ex
@@ -140,9 +140,7 @@ defmodule Phoenix.Channel.Client.Socket do
 
   def handle_info({:closed, reason}, state) do
     Logger.debug "Socket Closed: #{inspect reason}"
-    Enum.each(state.channels, fn(channel)-> send(channel, {:trigger, :phx_error}) end)
-    if state.reconnect == true, do: send(self, :connect)
-    state.sender.handle_close(reason, %{state | state: :disconnected})
+    {:stop, reason, state}
   end
 
   def terminate(reason, state) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"cowboy": {:hex, :cowboy, "1.0.2"},
-  "cowlib": {:hex, :cowlib, "1.0.1"},
-  "phoenix": {:git, "git://github.com/phoenixframework/phoenix.git", "3fc98f8b18095b6d155f5afd824f7c5e24447187", []},
-  "plug": {:hex, :plug, "0.13.0"},
-  "poison": {:hex, :poison, "1.4.0"},
-  "ranch": {:hex, :ranch, "1.1.0"},
+%{"cowboy": {:hex, :cowboy, "1.0.2", "876a2f63eaa5da5bd0610569d6402cabef8b3f48171233c11cfeee9f37d1f0c9", [:rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
+  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "3fc98f8b18095b6d155f5afd824f7c5e24447187", []},
+  "plug": {:hex, :plug, "0.13.0", "2fed890715c53a2e47a8c410fac5b198770aa7abe996cf85cd496c3492dc4bc8", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "poison": {:hex, :poison, "1.4.0", "cd5afb9db7f0d19487572fa28185b6d4de647f14235746824e77b3139b79b725", [:mix], []},
+  "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []}}

--- a/test/phoenix_channel_client_test.exs
+++ b/test/phoenix_channel_client_test.exs
@@ -136,7 +136,7 @@ defmodule PhoenixChannelClientTest do
 
   setup do
     {:ok, _} = ClientSocket.start_link()
-    {:ok, channel} = Phoenix.Channel.Client.channel(ClientChannel, socket: ClientSocket, topic: "rooms:admin-lobby", caller: self)
+    {:ok, channel} = Phoenix.Channel.Client.channel(ClientChannel, socket_client: ClientSocket, socket: ClientSocket, topic: "rooms:admin-lobby", caller: self)
     #{:ok, channel} = ClientChannel.start_link(socket: ClientSocket, topic: "rooms:admin-lobby", sender: self)
     {:ok, client_channel: channel}
   end
@@ -199,5 +199,5 @@ defmodule PhoenixChannelClientTest do
     refute_receive {:timeout, "foo:bar", ^ref}, 200
   end
 
-  
+
 end


### PR DESCRIPTION
I'm using Phoenix.Channel.Client for links between phoenix servers. I want to be able to send messages from local instance of phoenix to remote using websockets, but with your implementation I could have only one client connection process since socket param of client state  accepts module name and at the same time is registered globally by this name.

 So I added socket_client param and it now accepts module name of socket client module, and socket - it accepts pid of socket client process. Please review this little change.
