### PR TITLE
Updating README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Phoenix.Channel.Client
+# PhoenixChannelClient
 
 Work In Progress!
 - [x] client, channel and push API
@@ -25,7 +25,7 @@ Example usage
 Using the Phoenix Channel Client requires you add a Socket module to your supervision tree for handling the socket connection.
 ```elixir
 defmodule MySocket do
-  use Phoenix.Channel.Client.Socket, otp_app: :my_app
+  use PhoenixChannelClient.Socket, otp_app: :my_app
 end
 ```
 
@@ -38,7 +38,7 @@ config :my_app, MySocket,
 Channels function with callbacks inside a module
 ```elixir
 defmodule MyChannel do
-  use Phoenix.Channel.Client
+  use PhoenixChannelClient
 
   def handle_in("new_msg", payload, state) do
     {:noreply, state}
@@ -67,12 +67,10 @@ end
 
 usage
 ```elixir
-alias Phoenix.Channel.Client
 {:ok, socket} = MySocket.start_link
-Client.channel(MyChannel, socket: MySocket, topic: "rooms:lobby")
-# MyChannel.start_link(socket: MySocket, topic: "rooms:lobby")
-MyChannel.join(%{})
-MyChannel.leave()
+{:ok, channel} = PhoenixChannelClient.channel(MyChannel, socket: MySocket, topic: "rooms:lobby")
+MyChannel.join(channel, %{})
+MyChannel.leave(channel)
 
 push = MyChannel.push("new:message", %{})
 MyChannel.cancel_push(push)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Add phoenix_channel_client as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:phoenix_channel_client, "~> 0.0.1"} ]
+  [
+    {:phoenix_channel_client, "~> 0.0.1"},
+    {:poison, "~> 2.0"} #optional. You can use your own JSON serializer
+  ]
 end
 ```
 
@@ -28,7 +31,8 @@ end
 
 ```elixir
 config :my_app, MySocket,
-  url: "ws://localhost:4000/socket/websocket"
+  url: "ws://localhost:4000/socket/websocket",
+  serializer: Poison  
 ```
 
 Channels function with callbacks inside a module

--- a/lib/phoenix_channel_client.ex
+++ b/lib/phoenix_channel_client.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.Channel.Client do
+defmodule PhoenixChannelClient do
   use Behaviour
 
   defcallback handle_in(event :: String.t, payload :: map, state :: map) ::
@@ -6,14 +6,14 @@ defmodule Phoenix.Channel.Client do
 
   defcallback handle_reply(reply :: Tuple.t, state :: map) ::
               {:noreply, state :: map}
-              
+
   defcallback handle_close(reply :: Tuple.t, state :: map) ::
               {:noreply, state :: map} |
               {:stop, reason :: term, state :: map}
 
   defmacro __using__(_opts) do
     quote do
-      alias Phoenix.Channel.Client.Server
+      alias PhoenixChannelClient.Server
 
       @behaviour unquote(__MODULE__)
 
@@ -50,6 +50,6 @@ defmodule Phoenix.Channel.Client do
   end
 
   def channel(sender, opts) do
-    Phoenix.Channel.Client.Server.start_link(sender, opts)
+    PhoenixChannelClient.Server.start_link(sender, opts)
   end
 end

--- a/lib/phoenix_channel_client/adapter.ex
+++ b/lib/phoenix_channel_client/adapter.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.Channel.Client.Adapter do
+defmodule PhoenixChannelClient.Adapter do
   use Behaviour
 
   defcallback open(url :: String.t, opts :: Keyword.t) ::

--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -16,7 +16,7 @@ defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
     Logger.debug "WS Init"
     {:ok, %{
       opts: opts,
-      json_module: opts[:json_module],
+      serializer: opts[:serializer],
       sender: opts[:sender]
     }}
   end
@@ -27,7 +27,7 @@ defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
   """
   def websocket_handle({:text, msg}, _conn_state, state) do
     #Logger.debug "Handle in: #{inspect msg}"
-    send state.sender, {:receive, state.json_module.decode!(msg)}
+    send state.sender, {:receive, state.serializer.decode!(msg)}
     {:ok, state}
   end
 
@@ -36,7 +36,7 @@ defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
   """
   def websocket_info({:send, msg}, _conn_state, state) do
     #Logger.debug "Handle out: #{inspect json!(msg)}"
-    {:reply, {:text, state.json_module.encode!(msg)}, state}
+    {:reply, {:text, state.serializer.encode!(msg)}, state}
   end
 
   def websocket_info(:close, _conn_state, state) do

--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -1,5 +1,5 @@
-defmodule Phoenix.Channel.Client.Adapters.WebsocketClient do
-  @behaviour Phoenix.Channel.Client.Adapter
+defmodule PhoenixChannelClient.Adapters.WebsocketClient do
+  @behaviour PhoenixChannelClient.Adapter
 
   require Logger
 

--- a/lib/phoenix_channel_client/server.ex
+++ b/lib/phoenix_channel_client/server.ex
@@ -1,4 +1,4 @@
-defmodule Phoenix.Channel.Client.Server do
+defmodule PhoenixChannelClient.Server do
   use GenServer
   require Logger
 

--- a/lib/phoenix_channel_client/socket.ex
+++ b/lib/phoenix_channel_client/socket.ex
@@ -1,5 +1,4 @@
 defmodule Phoenix.Channel.Client.Socket do
-  alias Poison, as: JSON
   use Behaviour
   require Logger
 

--- a/test/phoenix_channel_client_test.exs
+++ b/test/phoenix_channel_client_test.exs
@@ -148,12 +148,12 @@ defmodule PhoenixChannelClientTest do
 
   require Logger
 
-  # test "socket can join a channel", context do
-  #   channel = context[:client_channel]
-  #   %{ref: ref} = ClientChannel.join(channel)
-  #   IO.puts "Ref: #{inspect ref}"
-  #   assert_receive {:ok, :join, _, ^ref}
-  # end
+  test "socket can join a channel", context do
+    channel = context[:client_channel]
+    %{ref: ref} = ClientChannel.join(channel)
+    IO.puts "Ref: #{inspect ref}"
+    assert_receive {:ok, :join, _, ^ref}
+  end
 
   test "socket can leave a channel", context do
     channel = context[:client_channel]

--- a/test/phoenix_channel_client_test.exs
+++ b/test/phoenix_channel_client_test.exs
@@ -112,11 +112,11 @@ defmodule PhoenixChannelClientTest do
   end
 
   defmodule ClientSocket do
-    use Phoenix.Channel.Client.Socket, otp_app: :channel_client
+    use PhoenixChannelClient.Socket, otp_app: :channel_client
   end
 
   defmodule ClientChannel do
-    use Phoenix.Channel.Client
+    use PhoenixChannelClient
 
     def handle_in(event, payload, state) do
       send(state.opts[:caller], {event, payload})
@@ -136,7 +136,7 @@ defmodule PhoenixChannelClientTest do
 
   setup do
     {:ok, _} = ClientSocket.start_link()
-    {:ok, channel} = Phoenix.Channel.Client.channel(ClientChannel, socket: ClientSocket, topic: "rooms:admin-lobby", caller: self)
+    {:ok, channel} = PhoenixChannelClient.channel(ClientChannel, socket: ClientSocket, topic: "rooms:admin-lobby", caller: self)
     #{:ok, channel} = ClientChannel.start_link(socket: ClientSocket, topic: "rooms:admin-lobby", sender: self)
     {:ok, client_channel: channel}
   end

--- a/test/phoenix_channel_client_test.exs
+++ b/test/phoenix_channel_client_test.exs
@@ -20,7 +20,7 @@ defmodule PhoenixChannelClientTest do
 
   Application.put_env(:channel_client, ClientSocket, [
     url: "ws://127.0.0.1:#{@port}/ws/admin/websocket",
-    json_module: Poison
+    serializer: Poison
   ])
 
   defmodule RoomChannel do
@@ -199,5 +199,5 @@ defmodule PhoenixChannelClientTest do
     refute_receive {:timeout, "foo:bar", ^ref}, 200
   end
 
-  
+
 end


### PR DESCRIPTION
It wasn't clear that you needed to supply a serializer in the docs so I added that. 
Changing `json_module` to `serializer` to match phoenix lingo for the json serializer.
