### PR TITLE
Add in a case for :econnrefused ondisconnect

### DIFF
--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -32,6 +32,11 @@ defmodule PhoenixChannelClient.Adapters.WebsocketClient do
     send state.sender, {:closed, :normal, self()}
     {:ok, state}
   end
+  def ondisconnect({:error, :econnrefused}, state) do
+    Logger.debug "Websocket Connection Refused"
+    send state.sender, {:closed, :normal, self()}
+    {:ok, state}
+  end
 
   @doc """
   Receives JSON encoded Socket.Message from remote WS endpoint and


### PR DESCRIPTION
If the server is down, websocket_client will call with the reason
`{:error, :econnrefused}`. Add a function to match that.

I am not sure how to test this, but this worked in local testing.