### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/phoenix_channel_client/adapters/websocket_client.ex
+++ b/lib/phoenix_channel_client/adapters/websocket_client.ex
@@ -5,7 +5,7 @@ defmodule PhoenixChannelClient.Adapters.WebsocketClient do
 
   def open(url, opts) do
     Logger.debug "Called Open"
-    :websocket_client.start_link(String.to_char_list(url), __MODULE__, opts, extra_headers: opts[:headers])
+    :websocket_client.start_link(String.to_charlist(url), __MODULE__, opts, extra_headers: opts[:headers])
   end
 
   def close(socket) do


### PR DESCRIPTION
Fix warning: String.to_char_list/1 is deprecated