### PR TITLE
Read socket config on init, rather than at compile-time.

### DIFF
--- a/lib/phoenix_channel_client/socket.ex
+++ b/lib/phoenix_channel_client/socket.ex
@@ -19,7 +19,6 @@ defmodule PhoenixChannelClient.Socket do
   defp config(opts) do
     quote do
       var!(otp_app) = unquote(opts)[:otp_app] || raise "socket expects :otp_app to be given"
-      var!(config) = Application.get_env(var!(otp_app), __MODULE__)
     end
   end
 
@@ -31,7 +30,7 @@ defmodule PhoenixChannelClient.Socket do
 
       def start_link() do
         unquote(Logger.debug("Socket start_link #{__MODULE__}"))
-        GenServer.start_link(PhoenixChannelClient.Socket, {unquote(__MODULE__), unquote(var!(config))}, name: __MODULE__)
+        GenServer.start_link(PhoenixChannelClient.Socket, {unquote(__MODULE__), config()}, name: __MODULE__)
       end
 
       def push(pid, topic, event, payload) do
@@ -51,6 +50,9 @@ defmodule PhoenixChannelClient.Socket do
       end
 
       defoverridable handle_close: 2
+      defp config do
+        Application.get_env(unquote(var!(otp_app)), __MODULE__)
+      end
     end
   end
 


### PR DESCRIPTION
Setting the macro variable to the be config contents meant that the config values were baked in to the compiled module. To change the config values then we needed to recompile; now it's done on initialisation.

Should also play better with REPLACE_OS_VARS if using in a release.