### PR TITLE
CaseCauseError fix

### DIFF
--- a/lib/phoenix_channel_client/server.ex
+++ b/lib/phoenix_channel_client/server.ex
@@ -124,7 +124,7 @@ defmodule PhoenixChannelClient.Server do
           | pushes: pushes
         })
 
-      {[], []} ->
+      {[], _} ->
         {:noreply, state}
     end
   end


### PR DESCRIPTION
Fix typo that was causing `** (CaseClauseError) no case clause matching: {[], [...]}`